### PR TITLE
Build example only on custom system property

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ A tool allowing for easy class modification at runtime, when using a normal java
 Note, this method comes with disadvantages, for example method modifiers may not be altered, new methods can not be created and neither can class inheritance be changed.
 
 
+## Maven repository
+
+```xml
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+```
+
+```xml
+	<dependency>
+	    <groupId>com.github.Yamakaja.RuntimeTransformer</groupId>
+	    <artifactId>api</artifactId>
+	    <version>master-SNAPSHOT</version>
+	</dependency>
+```
+
 ## Usage
 
 Lets assume we want to inject an event handler into the `setHealth` method of `EntityLiving`,
@@ -61,3 +78,11 @@ There are three types of Injection:
 - INSERT (Inserts your code at the beginning of the method)
 - OVERWRITE (Overwrites the method with your code)
 - APPEND (Adds code to the end of the method, only works on methods returning void)
+
+## Compiling
+
+Run this command to build the api project.
+`gradlew jar`
+
+If you want to build the example project add `-Pbuild-example`
+`gradlew jar -Pbuild-example`

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,9 @@
 rootProject.name = 'runtimetransformer'
 
-include 'example-plugin'
-project(":example-plugin").projectDir = "$rootDir/example-plugin" as File
+if(hasProperty("build-example")){
+  include 'example-plugin'
+  project(":example-plugin").projectDir = "$rootDir/example-plugin" as File
+}
 
 include 'agent'
 project(":agent").projectDir = "$rootDir/agent" as File


### PR DESCRIPTION
The example project has spigot (the complete project) as a dependency. This dependency is only available if you compile Spigot yourself. 

Using [jitpack.io](https://jitpack.io) it's possible to host Maven and Gradle projects for free (for public projects) on their servers. They build it directly from Github. That's currently not possible, because of the spigot dependency.

So I introduced a system property (`-Pbuild-example`) to only build the example project if it's present. As you can see [here](https://jitpack.io/com/github/games647/RuntimeTransformer/cond-example-a25f6c16fb-1/build.log) Jiitpack is then able to build the project and we could use it using their Maven repository.