### PR TITLE
Fix support for Java9+ runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ And that's pretty much it, now we just need to create our runtime transformer:
 new RuntimeTransformer( EntityLivingTransformer.class );
 ```
 
+For Java 9+ runtimes, you have to allow self attaching by adding this startup `-Djdk.attach.allowAttachSelf=true`
+parameter or creating the `RuntimeTransformer` instance in a separate process.
+
 And we're done.
 
 You can find more examples in the example plugin.

--- a/api/src/main/java/me/yamakaja/runtimetransformer/RuntimeTransformer.java
+++ b/api/src/main/java/me/yamakaja/runtimetransformer/RuntimeTransformer.java
@@ -11,19 +11,22 @@ import java.net.URLClassLoader;
 public class RuntimeTransformer {
 
     public RuntimeTransformer(Class<?>... transformers) {
-        URLClassLoader urlClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+        ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+        if (systemClassLoader instanceof URLClassLoader) {
+            URLClassLoader urlClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
 
-        try {
-            Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
-            method.setAccessible(true);
+            try {
+                Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+                method.setAccessible(true);
 
-            File file = new File(new File(System.getProperty("java.home")).getParent(), "lib/tools.jar");
-            if (!file.exists())
-                throw new RuntimeException("Not running with JDK!");
+                File file = new File(new File(System.getProperty("java.home")).getParent(), "lib/tools.jar");
+                if (!file.exists())
+                    throw new RuntimeException("Not running with JDK!");
 
-            method.invoke(urlClassLoader, file.toURI().toURL());
-        } catch (Throwable throwable) {
-            throwable.printStackTrace();
+                method.invoke(urlClassLoader, file.toURI().toURL());
+            } catch (Throwable throwable) {
+                throwable.printStackTrace();
+            }
         }
 
         TransformerUtils.attachAgent(TransformerUtils.saveAgentJar(), transformers);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'base'
 
 subprojects {
     apply plugin: 'java'
-    sourceCompatibility = 1.8
+    sourceCompatibility = JavaVersion.VERSION_1_8
 
     repositories {
         mavenCentral()

--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly "org.spigotmc:spigot:1.12.2-R0.1-SNAPSHOT"
+    compileOnly "org.spigotmc:spigot:1.15.2-R0.1-SNAPSHOT"
     compile project(":api")
     compileOnly project(":agent")
 }

--- a/example-plugin/build.gradle
+++ b/example-plugin/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly "org.spigotmc:spigot:1.11.2-R0.1-SNAPSHOT"
+    compileOnly "org.spigotmc:spigot:1.12.2-R0.1-SNAPSHOT"
     compile project(":api")
     compileOnly project(":agent")
 }

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/ExampleTransformationPlugin.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/ExampleTransformationPlugin.java
@@ -4,12 +4,11 @@ import me.yamakaja.runtimetransformer.RuntimeTransformer;
 import me.yamakaja.runtimetransformer.plugin.transformer.CraftServerTransformer;
 import me.yamakaja.runtimetransformer.plugin.transformer.EntityLivingTransformer;
 import me.yamakaja.runtimetransformer.plugin.transformer.SkullMetaTransformer;
-import org.bukkit.Bukkit;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/CraftServerTransformer.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/CraftServerTransformer.java
@@ -3,7 +3,8 @@ package me.yamakaja.runtimetransformer.plugin.transformer;
 import me.yamakaja.runtimetransformer.annotation.Inject;
 import me.yamakaja.runtimetransformer.annotation.InjectionType;
 import me.yamakaja.runtimetransformer.annotation.Transform;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 
 /**
  * Created by Yamakaja on 20.05.17.

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/CraftServerTransformer.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/CraftServerTransformer.java
@@ -4,7 +4,7 @@ import me.yamakaja.runtimetransformer.annotation.Inject;
 import me.yamakaja.runtimetransformer.annotation.InjectionType;
 import me.yamakaja.runtimetransformer.annotation.Transform;
 
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 
 /**
  * Created by Yamakaja on 20.05.17.

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/EntityLivingTransformer.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/EntityLivingTransformer.java
@@ -4,9 +4,10 @@ import me.yamakaja.runtimetransformer.annotation.Inject;
 import me.yamakaja.runtimetransformer.annotation.InjectionType;
 import me.yamakaja.runtimetransformer.annotation.Transform;
 
-import net.minecraft.server.v1_12_R1.DamageSource;
-import net.minecraft.server.v1_12_R1.EntityLiving;
-import net.minecraft.server.v1_12_R1.World;
+import net.minecraft.server.v1_15_R1.DamageSource;
+import net.minecraft.server.v1_15_R1.EntityLiving;
+import net.minecraft.server.v1_15_R1.EntityTypes;
+import net.minecraft.server.v1_15_R1.World;
 
 import org.bukkit.Bukkit;
 
@@ -16,20 +17,20 @@ import org.bukkit.Bukkit;
 @Transform(EntityLiving.class)
 public abstract class EntityLivingTransformer extends EntityLiving {
 
-    private EntityLivingTransformer(World world) {
-        super(world);
+    protected EntityLivingTransformer(EntityTypes<? extends EntityLiving> entitytypes, World world) {
+        super(entitytypes, world);
     }
 
     @Inject(InjectionType.INSERT)
-    public void _init_(World world) {
+    public void _init_(EntityTypes<? extends EntityLiving> entitytypes, World world) {
         Bukkit.broadcastMessage("Entity created!");
         throw null;
     }
 
     // Injecting into a private method
     @Inject(InjectionType.INSERT)
-    private boolean e(DamageSource src) {
-        Bukkit.broadcastMessage("Checked " + this.getName() + " for totem @ " + (int) this.locX + ", " + (int) this.locY + ", " + (int) this.locZ + "!");
+    private boolean f(DamageSource src) {
+        Bukkit.broadcastMessage("Checked " + this.getName() + " for totem @ " + (int) this.locX() + ", " + (int) this.locY() + ", " + (int) this.locZ() + "!");
         throw null; // Let original method continue execution
     }
 

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/EntityLivingTransformer.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/EntityLivingTransformer.java
@@ -3,9 +3,11 @@ package me.yamakaja.runtimetransformer.plugin.transformer;
 import me.yamakaja.runtimetransformer.annotation.Inject;
 import me.yamakaja.runtimetransformer.annotation.InjectionType;
 import me.yamakaja.runtimetransformer.annotation.Transform;
-import net.minecraft.server.v1_11_R1.DamageSource;
-import net.minecraft.server.v1_11_R1.EntityLiving;
-import net.minecraft.server.v1_11_R1.World;
+
+import net.minecraft.server.v1_12_R1.DamageSource;
+import net.minecraft.server.v1_12_R1.EntityLiving;
+import net.minecraft.server.v1_12_R1.World;
+
 import org.bukkit.Bukkit;
 
 /**
@@ -26,7 +28,7 @@ public abstract class EntityLivingTransformer extends EntityLiving {
 
     // Injecting into a private method
     @Inject(InjectionType.INSERT)
-    private boolean d(DamageSource src) {
+    private boolean e(DamageSource src) {
         Bukkit.broadcastMessage("Checked " + this.getName() + " for totem @ " + (int) this.locX + ", " + (int) this.locY + ", " + (int) this.locZ + "!");
         throw null; // Let original method continue execution
     }

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/SkullMetaTransformer.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/SkullMetaTransformer.java
@@ -1,30 +1,29 @@
 package me.yamakaja.runtimetransformer.plugin.transformer;
 
-import com.google.common.base.Predicate;
 import com.mojang.authlib.GameProfile;
+
 import me.yamakaja.runtimetransformer.annotation.CallParameters;
 import me.yamakaja.runtimetransformer.annotation.Inject;
 import me.yamakaja.runtimetransformer.annotation.InjectionType;
 import me.yamakaja.runtimetransformer.annotation.TransformByName;
-import net.minecraft.server.v1_11_R1.GameProfileSerializer;
-import net.minecraft.server.v1_11_R1.NBTTagCompound;
-import net.minecraft.server.v1_11_R1.TileEntitySkull;
 
-import javax.annotation.Nullable;
+import net.minecraft.server.v1_12_R1.GameProfileSerializer;
+import net.minecraft.server.v1_12_R1.NBTTagCompound;
+import net.minecraft.server.v1_12_R1.TileEntitySkull;
 
 /**
  * Created by Yamakaja on 3/3/18.
  */
-@TransformByName("org.bukkit.craftbukkit.v1_11_R1.inventory.CraftMetaSkull")
+@TransformByName("org.bukkit.craftbukkit.v1_12_R1.inventory.CraftMetaSkull")
 public class SkullMetaTransformer {
 
     private GameProfile profile;
 
     @CallParameters(
             type = CallParameters.Type.SPECIAL,
-            owner = "org/bukkit/craftbukkit/v1_11_R1/inventory/CraftMetaItem",
+            owner = "org/bukkit/craftbukkit/v1_12_R1/inventory/CraftMetaItem",
             name = "applyToItem",
-            desc = "(Lnet/minecraft/server/v1_11_R1/NBTTagCompound;)V"
+            desc = "(Lnet/minecraft/server/v1_12_R1/NBTTagCompound;)V"
     )
     private native void super_applyToItem(NBTTagCompound tag);
 
@@ -36,16 +35,13 @@ public class SkullMetaTransformer {
             GameProfileSerializer.serialize(owner, this.profile);
             tag.set("SkullOwner", owner);
             System.out.println("Set owner to " + owner);
-            TileEntitySkull.b(this.profile, new Predicate<GameProfile>() {
-                @Override
-                public boolean apply(@Nullable GameProfile gameProfile) {
-                    NBTTagCompound newOwner = new NBTTagCompound();
-                    GameProfileSerializer.serialize(newOwner, gameProfile);
-                    tag.set("SkullOwner", newOwner);
-                    System.out.println("Received game profile!");
-                    return false;
-                }
-            });
+            TileEntitySkull.b(this.profile, gameProfile -> {
+                NBTTagCompound newOwner = new NBTTagCompound();
+                GameProfileSerializer.serialize(newOwner, gameProfile);
+                tag.set("SkullOwner", newOwner);
+                System.out.println("Received game profile!");
+                return false;
+            }, true);
         }
 
     }

--- a/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/SkullMetaTransformer.java
+++ b/example-plugin/src/main/java/me/yamakaja/runtimetransformer/plugin/transformer/SkullMetaTransformer.java
@@ -7,23 +7,23 @@ import me.yamakaja.runtimetransformer.annotation.Inject;
 import me.yamakaja.runtimetransformer.annotation.InjectionType;
 import me.yamakaja.runtimetransformer.annotation.TransformByName;
 
-import net.minecraft.server.v1_12_R1.GameProfileSerializer;
-import net.minecraft.server.v1_12_R1.NBTTagCompound;
-import net.minecraft.server.v1_12_R1.TileEntitySkull;
+import net.minecraft.server.v1_15_R1.GameProfileSerializer;
+import net.minecraft.server.v1_15_R1.NBTTagCompound;
+import net.minecraft.server.v1_15_R1.TileEntitySkull;
 
 /**
  * Created by Yamakaja on 3/3/18.
  */
-@TransformByName("org.bukkit.craftbukkit.v1_12_R1.inventory.CraftMetaSkull")
+@TransformByName("org.bukkit.craftbukkit.v1_15_R1.inventory.CraftMetaSkull")
 public class SkullMetaTransformer {
 
     private GameProfile profile;
 
     @CallParameters(
             type = CallParameters.Type.SPECIAL,
-            owner = "org/bukkit/craftbukkit/v1_12_R1/inventory/CraftMetaItem",
+            owner = "org/bukkit/craftbukkit/v1_15_R1/inventory/CraftMetaItem",
             name = "applyToItem",
-            desc = "(Lnet/minecraft/server/v1_12_R1/NBTTagCompound;)V"
+            desc = "(Lnet/minecraft/server/v1_15_R1/NBTTagCompound;)V"
     )
     private native void super_applyToItem(NBTTagCompound tag);
 


### PR DESCRIPTION
Java 9 changed some internals including that the `getSystemClassLoader` no longer returns a `URLClassLoader` and therefore the reflection call `addURL` to add the native JDK `VirtualMachine` class to the Classpath no longer works (`ClassCastException`). 

Using OpenJDK 10 (Development edition), I found out that loading those classes (now in a jmod file) is longer necessary, but since Java 9 you are required to add a startup flag or run in a separate process.

Maybe it needs verification from someone else, that this fix works in other environments too.